### PR TITLE
feature/13 - support scroll: false in results data strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.1.7
+﻿# 0.1.8
+* Elasticsearch scrolling off by default in results strategy
+
+# 0.1.7
 * Better CSV processing.
 
 # 0.1.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -34,7 +34,7 @@ export const results = ({
       highlight,
     }
 
-    if (scroll !== false) {
+    if (scroll) {
       resultsConfig.scroll = true
       resultsConfig.scrollId = scrollId
     }

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -20,7 +20,7 @@ export const results = ({
   sortField,
   sortDir,
   highlight,
-  scroll
+  scroll,
 }) => {
   let formatTree = ({ pageSize, page, scrollId }) => {
     let resultsConfig = {
@@ -43,10 +43,7 @@ export const results = ({
       ..._.pick(['schema', 'join'], tree),
       type: 'group',
       key: 'limitedSearchRoot',
-      children: [
-        setFilterOnly(tree),
-        resultsConfig,
-      ],
+      children: [setFilterOnly(tree), resultsConfig],
     }
   }
 

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -20,27 +20,35 @@ export const results = ({
   sortField,
   sortDir,
   highlight,
+  scroll
 }) => {
-  let formatTree = ({ pageSize, page, scrollId }) => ({
-    ..._.pick(['schema', 'join'], tree),
-    type: 'group',
-    key: 'limitedSearchRoot',
-    children: [
-      setFilterOnly(tree),
-      {
-        key: 'results',
-        type: 'results',
-        pageSize,
-        page,
-        include,
-        sortField,
-        sortDir,
-        scroll: true,
-        scrollId,
-        highlight,
-      },
-    ],
-  })
+  let formatTree = ({ pageSize, page, scrollId }) => {
+    let resultsConfig = {
+      key: 'results',
+      type: 'results',
+      pageSize,
+      page,
+      include,
+      sortField,
+      sortDir,
+      highlight,
+    }
+
+    if (scroll !== false) {
+      resultsConfig.scroll = true
+      resultsConfig.scrollId = scrollId
+    }
+
+    return {
+      ..._.pick(['schema', 'join'], tree),
+      type: 'group',
+      key: 'limitedSearchRoot',
+      children: [
+        setFilterOnly(tree),
+        resultsConfig,
+      ],
+    }
+  }
 
   let scrollId = null
   let getNext = async () => {


### PR DESCRIPTION
Fixes #13 

### Description
* allows passing in `scroll: false` for compatibility with paginating results and other client-facing factors

### Test
* tested with internal project exports and web client