### PR TITLE
CSV export issue when not all data exists on the 1st row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.1.8
+﻿# 0.1.9
+* Fix missing columns issue due to not all columns having results in the first row
+
+# 0.1.8
 * Elasticsearch scrolling off by default in results strategy
 
 # 0.1.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -65,6 +65,7 @@ export const results = ({
   }
 
   return {
+    include,
     formatTree,
     getTotalRecords,
     hasNext: () => page <= totalPages,

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -41,13 +41,12 @@ export const stream = _.curry(async ({ strategy, stream }) => {
 // Also fill in any keys which are present in the included keys but not in the passed in object
 export const formatValues = (
   rules = {},
-  includedKeys = [],
-  defaultDisplay = _.identity
+  includedKeys = []
 ) => _.map(obj => {
   // Format all values of the passed in object
   let resultObject = F.mapValuesIndexed((value, key) => rules[key]
-    ? (rules[key].display || defaultDisplay)(value)
-    : defaultDisplay(value)
+    ? rules[key].display(value)
+    : value
   , obj)
   // Fill the empty properties for the objects missing the expected keys
   _.each(key => {
@@ -62,7 +61,7 @@ export const formatValues = (
 export const formatHeaders = (
   rules,
   defaultLabel = _.startCase
-) => _.map(key => _.has(`${key}.label`, rules) ? rules[key].label : defaultLabel(key))
+) => _.map(key => _.get(`${key}.label`, rules) || defaultLabel(key))
 
 // Extract keys from first row
 export let extractHeadersFromFirstRow = _.flow(

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -39,29 +39,25 @@ export const stream = _.curry(async ({ strategy, stream }) => {
 
 // Format object values based on passed formatter or _.identity
 // Also fill in any keys which are present in the included keys but not in the passed in object
-export const formatValues = (
-  rules = {},
-  includedKeys = []
-) => _.map(obj => {
-  // Format all values of the passed in object
-  let resultObject = F.mapValuesIndexed((value, key) => rules[key]
-    ? rules[key].display(value)
-    : value
-  , obj)
-  // Fill the empty properties for the objects missing the expected keys
-  _.each(key => {
-    if(!resultObject[key]) {
-      resultObject[key] = ''
-    }
-  }, includedKeys)
-  return resultObject
-})
+export const formatValues = (rules = {}, includedKeys = []) =>
+  _.map(obj => {
+    // Format all values of the passed in object
+    let resultObject = F.mapValuesIndexed(
+      (value, key) => (rules[key] ? rules[key].display(value) : value),
+      obj
+    )
+    // Fill the empty properties for the objects missing the expected keys
+    _.each(key => {
+      if (!resultObject[key]) {
+        resultObject[key] = ''
+      }
+    }, includedKeys)
+    return resultObject
+  })
 
 // Format the column headers with passed rules or _.startCase
-export const formatHeaders = (
-  rules,
-  defaultLabel = _.startCase
-) => _.map(key => _.get(`${key}.label`, rules) || defaultLabel(key))
+export const formatHeaders = (rules, defaultLabel = _.startCase) =>
+  _.map(key => _.get(`${key}.label`, rules) || defaultLabel(key))
 
 // Extract keys from first row
 export let extractHeadersFromFirstRow = _.flow(
@@ -116,7 +112,9 @@ export const CSVStream = async ({
       // this is not accurate and only works in the case where the first row has all the data for all columns
       if (_.isEmpty(columnHeaders)) {
         // Extract column names from first object and format them
-        columnHeaders = formatHeaders(formatRules)(extractHeadersFromFirstRow(formattedData))
+        columnHeaders = formatHeaders(formatRules)(
+          extractHeadersFromFirstRow(formattedData)
+        )
       }
 
       // Convert data to CSV rows

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -80,9 +80,9 @@ let transformCell = _.flow(
 )
 
 // Convert array of objects to array of arrays
-export let convertData = (data, columnKeys) => {
+export let convertData = (data, columnHeaders) => {
   // Extract data from object
-  let transformRow = row => _.map(key => _.get(key, row), columnKeys)
+  let transformRow = row => _.map(key => _.get(key, row), columnHeaders)
   return _.map(transformRow, data)
 }
 
@@ -117,7 +117,7 @@ export const CSVStream = async ({
 }) => {
   let records = 0
   let totalRecords = await strategy.getTotalRecords()
-  let includeColumns = _.getOr([], 'include', strategy)
+  let includedKeys = _.getOr([], 'include', strategy)
   let columnHeaders = []
 
   await onWrite({
@@ -131,14 +131,14 @@ export const CSVStream = async ({
 
       let formattedData = format(formatRules)(chunk)
 
-      // If no includeColumns ware passed get them from the first row
+      // If no includedKeys ware passed get them from the first row
       // this is not accurate and only works in the case where the first row has all the data for all columns
-      if (_.isEmpty(includeColumns)) {
+      if (_.isEmpty(includedKeys)) {
         // Extract column names from first object
         columnHeaders = extractKeysFromFirstRow(formattedData)
       } else {
-        // Start Case the passed includeColumns
-        columnHeaders = convertColumns(includeColumns)
+        // Start Case the passed includedKeys
+        columnHeaders = convertColumns(includedKeys)
       }
       // Convert data to CSV rows
       let rows = convertData(formattedData, columnHeaders)

--- a/test/exportStrategies.test.js
+++ b/test/exportStrategies.test.js
@@ -100,8 +100,8 @@ describe('exportStrategies', () => {
           {
             chunk: [
               {
-                'First Prop': 'FIRST',
-                'Second Property': 'SECOND',
+                'firstProperty': 'FIRST',
+                'secondProperty': 'SECOND',
               },
             ],
             records: 1,
@@ -112,8 +112,8 @@ describe('exportStrategies', () => {
           {
             chunk: [
               {
-                'First Prop': 'FIRST',
-                'Second Property': 'SECOND',
+                'firstProperty': 'FIRST',
+                'secondProperty': 'SECOND',
               },
             ],
             records: 2,
@@ -175,8 +175,8 @@ describe('exportStrategies', () => {
           {
             chunk: [
               {
-                'Title': undefined,
-                'Agency Name': 'Agency A',
+                'Title': '',
+                'AgencyName': 'Agency A',
               },
             ],
             records: 1,
@@ -187,8 +187,8 @@ describe('exportStrategies', () => {
           {
             chunk: [
               {
-                'Title': undefined,
-                'Agency Name': 'Agency A',
+                'Title': '',
+                'AgencyName': 'Agency A',
               },
             ],
             records: 2,
@@ -208,27 +208,76 @@ describe('exportStrategies', () => {
   })
   describe('utils', () => {
     let {
-      convertData,
-      convertColumns,
+      formatHeaders,
+      formatValues,
       rowsToCSV,
-      extractKeysFromFirstRow,
+      extractHeadersFromFirstRow,
     } = exportStrategies
     let columnKeys = ['name', 'age']
     let chunk = [
       { name: 'Bob "Bobby" Brown', age: 36 },
       { name: 'Joe Blow', age: 40 },
     ]
-    it('extractKeysFromFirstRow', () => {
-      expect(extractKeysFromFirstRow(chunk)).toEqual(['name', 'age'])
+    it('extractHeadersFromFirstRow', () => {
+      expect(extractHeadersFromFirstRow(chunk)).toEqual(['name', 'age'])
     })
-    it('convertData', () => {
-      expect(convertData(chunk, columnKeys)).toEqual([
-        ['Bob "Bobby" Brown', 36],
-        ['Joe Blow', 40],
+    it('formatValues with no rules', () => {
+      expect(formatValues({})(chunk)).toEqual([
+        {"age": 36, "name": "Bob \"Bobby\" Brown"},
+        {"age": 40, "name": "Joe Blow"}
       ])
     })
-    it('convertColumns', () => {
-      expect(convertColumns(columnKeys)).toEqual(['Name', 'Age'])
+    it('formatValues with rules', () => {
+      expect(formatValues({
+        name: { display: _.toLower },
+        age: { display: _.toString }
+      })(chunk)).toEqual([
+        {age: "36", name: "bob \"bobby\" brown"},
+        {age: "40", name: "joe blow"}
+      ])
+    })
+    it('formatValues with no rules and empty props', () => {
+      let columnKeys = [ "AgencyName", "FullName", "Title", "AgencyType", "AddressState" ]
+      let data = [
+        { "AgencyName": "ABC", "AgencyType": "Private Schools", "AddressState": "IL" },
+        { "AgencyName": "DEF", "FullName": "D P", "Title": "Auditor", "AgencyType": "State", "AddressState": "CA" },
+        { "AddressState": "FL" }
+      ]
+      expect(formatValues({}, columnKeys)(data)).toEqual([
+        {AgencyName: "ABC", AgencyType: "Private Schools", AddressState: "IL", Title: '', FullName: ''},
+        {AgencyName: "DEF", AgencyType: "State", AddressState: "CA", Title: 'Auditor', FullName: 'D P'},
+        {AgencyName: "", AgencyType: "", AddressState: "FL", Title: '', FullName: ''}
+      ])
+    })
+    it('formatValues with rules and empty props', () => {
+      let columnKeys = [ "AgencyName", "FullName", "Title", "AgencyType", "AddressState" ]
+      let data = [
+        { "AgencyName": "ABC", "AgencyType": "Private Schools", "AddressState": "IL" },
+        { "AgencyName": "DEF", "FullName": "D P", "Title": "Auditor", "AgencyType": "State", "AddressState": "CA" },
+        { "AddressState": "FL" }
+      ]
+      let rules = {
+        AgencyType: {
+          display: _.toUpper
+        },
+        AddressState: {
+          display: _.toLower
+        }
+      }
+      expect(formatValues(rules, columnKeys)(data)).toEqual([
+        {AgencyName: "ABC", AgencyType: "PRIVATE SCHOOLS", AddressState: "il", Title: '', FullName: ''},
+        {AgencyName: "DEF", AgencyType: "STATE", AddressState: "ca", Title: 'Auditor', FullName: 'D P'},
+        {AgencyName: "", AgencyType: "", AddressState: "fl", Title: '', FullName: ''}
+      ])
+    })
+    it('formatHeaders with no rules', () => {
+      expect(formatHeaders({})(columnKeys)).toEqual(['Name', 'Age'])
+    })
+    it('formatHeaders with rules', () => {
+      expect(formatHeaders({
+        name: { label: 'A'},
+        age: { label: 'B'}
+      })(columnKeys)).toEqual(['A', 'B'])
     })
     it('rowsToCSV', () => {
       let rows = [['Name', 'Age'], ['Bob "Bobby" Brown', 36], ['Joe Blow', 40]]


### PR DESCRIPTION
When the data provided to the CSV export strategy does not contain data in EVERY column but only in few of them the export ends up exporting only those columns with data. This is due to getting the list of the columns from the first row and relying on the assumption that all of them would have data. 

The fix exposes the `include` from the dataStrategy so that the export strategy can reliably know exactly the order and the columns that would need to be in the export. This way nothing extra needs to be passed to the `contexture-export` and things are handled internally. 

Note that if the `CSV` export strategy would still attempt to get the column headers from the first row *IF* the `include` is not provided by the passed in `strategy`.

Open to ideas how in other way we would know exactly which columns to export when the initial row does not have all the data as assumed. That to me however made the most sense.