### PR TITLE
Support result nodes without the weird `response` wrapper :)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.1.10
+# 0.2.0
+* Add support for `results` nodes which don't wrap their context objects in `response` (like contexture-memory)
+
+# 0.1.10
 * Only call display if fn exists.
 
 # 0.1.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -54,12 +54,18 @@ export const results = ({
     )
     scrollId = result.context.scrollId
     page++
-    return _.map('_source', F.cascade(['response.results', 'results'], result.context))
+    return _.map(
+      '_source',
+      F.cascade(['response.results', 'results'], result.context)
+    )
   }
 
   const getTotalRecords = async () => {
     let data = await service(formatTree({ pageSize: 1, page: 1 }))
-    let totalRecords = F.cascade(['response.totalRecords', 'totalRecords'], getTreeResults(data).context)
+    let totalRecords = F.cascade(
+      ['response.totalRecords', 'totalRecords'],
+      getTreeResults(data).context
+    )
     let expectedRecords = totalPages * pageSize
     return totalRecords < expectedRecords ? totalRecords : expectedRecords
   }

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -1,3 +1,4 @@
+import F from 'futil'
 import _ from 'lodash/fp'
 import { setFilterOnly } from './utils'
 

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -54,12 +54,12 @@ export const results = ({
     )
     scrollId = result.context.scrollId
     page++
-    return _.map('_source', result.context.response.results)
+    return _.map('_source', F.cascade(['response.results', 'results'], result.context))
   }
 
   const getTotalRecords = async () => {
     let data = await service(formatTree({ pageSize: 1, page: 1 }))
-    let totalRecords = getTreeResults(data).context.response.totalRecords
+    let totalRecords = F.cascade(['response.totalRecords', 'totalRecords'], getTreeResults(data).context)
     let expectedRecords = totalPages * pageSize
     return totalRecords < expectedRecords ? totalRecords : expectedRecords
   }

--- a/test/dataStrategies.test.js
+++ b/test/dataStrategies.test.js
@@ -64,10 +64,10 @@ describe('dataStrategies', () => {
       })
     }
     describe(' with contexts wrapped in `response`', () => {
-       resultsTests(prepareSimpleStrategy(getSimpleService(!wrap)))
+      resultsTests(prepareSimpleStrategy(getSimpleService(!wrap)))
     })
     describe(' with contexts not wrapped in `response`', () => {
-       resultsTests(prepareSimpleStrategy(getSimpleService(wrap)))
+      resultsTests(prepareSimpleStrategy(getSimpleService(wrap)))
     })
   })
 

--- a/test/dataStrategies.test.js
+++ b/test/dataStrategies.test.js
@@ -64,10 +64,10 @@ describe('dataStrategies', () => {
       })
     }
     describe(' with contexts wrapped in `response`', () => {
-      resultsTests(prepareSimpleStrategy(getSimpleService(!wrap)))
+      resultsTests(prepareSimpleStrategy(getSimpleService(false)))
     })
     describe(' with contexts not wrapped in `response`', () => {
-      resultsTests(prepareSimpleStrategy(getSimpleService(wrap)))
+      resultsTests(prepareSimpleStrategy(getSimpleService(true)))
     })
   })
 

--- a/test/dataStrategies.test.js
+++ b/test/dataStrategies.test.js
@@ -64,10 +64,10 @@ describe('dataStrategies', () => {
       })
     }
     describe(' with contexts wrapped in `response`', () => {
-       resultsTests(prepareSimpleStrategy(getSimpleService(!wrap))
+       resultsTests(prepareSimpleStrategy(getSimpleService(!wrap)))
     })
     describe(' with contexts not wrapped in `response`', () => {
-       resultsTests(prepareSimpleStrategy(getSimpleService(wrap))
+       resultsTests(prepareSimpleStrategy(getSimpleService(wrap)))
     })
   })
 


### PR DESCRIPTION
This is the case for contexture-memory and, hopefully, contexture-elasticsearch and contexture-mongo one day.