### PR TITLE
Fix for the “_source” issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+﻿# 0.2.2
+* Fix an issue with dataStrategies which prevents mongo exports
+
 # 0.2.1
 * Enable support for include in terms stats data strategy.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -56,7 +56,7 @@ export const results = ({
     scrollId = result.context.scrollId
     page++
     return _.map(
-      '_source',
+      F.getOrReturn('_source'),
       F.cascade(['response.results', 'results'], result.context)
     )
   }


### PR DESCRIPTION
Fixes the `_source` field issue which is a ES specific field and breaks mongo exports.