### PR TITLE
Do not flatten record during display formatting in `formatValues`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.2.4
+﻿# 0.2.5
+* Do not flatten record during display formatting in `formatValues`
+
+# 0.2.4
 * Pass record as second argument to field display function in `formatValues` 
 
 # 0.2.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/test/exportStrategies.test.js
+++ b/test/exportStrategies.test.js
@@ -266,11 +266,18 @@ describe('exportStrategies', () => {
         })(chunk)
       ).toEqual([
         {
-          'Person.age': '36',
-          'Person.name': 'bob "bobby" brown',
-          'Person.weight': 160,
+          Person: {
+            age: '36',
+            name: 'bob "bobby" brown',
+            weight: 160,
+          },
         },
-        { 'Person.age': '40', 'Person.name': 'joe blow' },
+        {
+          Person: {
+            age: '40',
+            name: 'joe blow',
+          },
+        },
       ])
     })
     it('formatValues with no rules and empty props', () => {
@@ -387,7 +394,11 @@ describe('exportStrategies', () => {
       ).toEqual(['A', 'B'])
     })
     it('rowsToCSV', () => {
-      let rows = [['Name', 'Age'], ['Bob "Bobby" Brown', 36], ['Joe Blow', 40]]
+      let rows = [
+        ['Name', 'Age'],
+        ['Bob "Bobby" Brown', 36],
+        ['Joe Blow', 40],
+      ]
       expect(rowsToCSV(rows)).toEqual(`"Name","Age"
 "Bob ""Bobby"" Brown","36"
 "Joe Blow","40"


### PR DESCRIPTION
- Avoid flattening the record during display formatting to allow applying display functions to array/object fields specified in format rules
- Apply formatting only to record fields specified in the format rules being passed as opposed to looping through all fields on all records

https://github.com/smartprocure/spark/issues/5277