### PR TITLE
Pass `skipCount` to resultConfig in results data strategy so that sea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.2.5
+﻿# 0.2.6
+* Pass `skipCount` to resultConfig in results data strategy so that search provider can skip `count query` if supported
+
+# 0.2.5
 * Do not flatten record during display formatting in `formatValues`
 
 # 0.2.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -24,7 +24,7 @@ export const results = ({
   scroll,
   ...rest
 }) => {
-  let formatTree = ({ pageSize, page, scrollId }) => {
+  let formatTree = ({ pageSize, page, scrollId, skipCount = false }) => {
     let resultsConfig = {
       key: 'results',
       type: 'results',
@@ -34,6 +34,7 @@ export const results = ({
       sortField,
       sortDir,
       highlight,
+      skipCount,
       ...rest,
     }
 
@@ -53,7 +54,7 @@ export const results = ({
   let scrollId = null
   let getNext = async () => {
     let result = getTreeResults(
-      await service(formatTree({ page, pageSize, scrollId }))
+      await service(formatTree({ page, pageSize, scrollId, skipCount: true }))
     )
     scrollId = result.context.scrollId
     page++


### PR DESCRIPTION
Pass `skipCount` to resultConfig in results data strategy so that search provider can skip `count query` if supported