### PR TITLE
Use original record for each field's display function in `formatValues`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.2.6
+﻿# 0.2.7
+* Use original record for each field's display function in `formatValues`
+
+# 0.2.6
 * Pass `skipCount` to resultConfig in results data strategy so that search provider can skip `count query` if supported
 
 # 0.2.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -47,8 +47,9 @@ export let formatValues = (rules = {}, includeKeys = []) => {
   let displayRules = _.flow(_.mapValues('display'), F.compactObject)(rules)
 
   let formattedRecordValues = record => {
+    let clone = _.cloneDeep(record)
     F.eachIndexed((display, field) =>
-      F.setOn(field, display(_.get(field, record), record), record)
+      F.setOn(field, display(_.get(field, clone), clone), record)
     )(displayRules)
     return record
   }


### PR DESCRIPTION
Store a clone of the record being formatted for display and use as param for any custom display function, in case there are display functions relying on interdependent fields