### PR TITLE
feature/27 - results dataStrategy: spread _source onto root result items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.2.7
+﻿# 0.2.8
+* `results` dataStrategy: spread `_source` onto results items
+
+# 0.2.7
 * Use original record for each field's display function in `formatValues`
 
 # 0.2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ﻿# 0.2.8
-* `results` dataStrategy: spread `_source` onto results items
+* `results` dataStrategy: spread `_source` onto results items.
 
 # 0.2.7
 * Use original record for each field's display function in `formatValues`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -62,7 +62,7 @@ export const results = ({
     // interested in the _source properties but may occasionally want other props like _id.
     // This will be removed with #28 when a contexture-elasticsearch upgrade is complete
     return _.map(
-      r => ({ ..._.omit(['_source'], r), ..._.getOr({}, '_source', r) }),
+      r => !_.isString(r._source) ? ({ ..._.omit(['_source'], r), ..._.getOr({}, '_source', r) }): r._source ? r._source : r,
       F.cascade(['response.results', 'results'], result.context)
     )
   }

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -1,6 +1,7 @@
 import F from 'futil'
 import _ from 'lodash/fp'
 import { setFilterOnly } from './utils'
+import { flattenProp } from './futil'
 
 let getTreeResults = _.flow(
   _.get('children'),
@@ -62,7 +63,7 @@ export const results = ({
     // interested in the _source properties but may occasionally want other props like _id.
     // This will be removed with #28 when a contexture-elasticsearch upgrade is complete
     return _.map(
-      F.when('_source', r => ({ ..._.omit('_source', r), ...r._source })),
+      flattenProp('_source'),
       F.cascade(['response.results', 'results'], result.context)
     )
   }

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -62,7 +62,7 @@ export const results = ({
     // interested in the _source properties but may occasionally want other props like _id.
     // This will be removed with #28 when a contexture-elasticsearch upgrade is complete
     return _.map(
-      r => !_.isString(r._source) ? ({ ..._.omit(['_source'], r), ..._.getOr({}, '_source', r) }): r._source ? r._source : r,
+      r => _.isObject(r._source) ? ({ ..._.omit(['_source'], r), ..._.getOr({}, '_source', r) }): r._source ? r._source : r,
       F.cascade(['response.results', 'results'], result.context)
     )
   }

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -62,7 +62,7 @@ export const results = ({
     // interested in the _source properties but may occasionally want other props like _id.
     // This will be removed with #28 when a contexture-elasticsearch upgrade is complete
     return _.map(
-      r => _.isObject(r._source) ? ({ ..._.omit(['_source'], r), ..._.getOr({}, '_source', r) }): r._source ? r._source : r,
+      F.when('_source', r => ({ ..._.omit('_source', r), ...r._source })),
       F.cascade(['response.results', 'results'], result.context)
     )
   }

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -58,6 +58,9 @@ export const results = ({
     )
     scrollId = result.context.scrollId
     page++
+    // We return _source flattened onto the root result items because we're mostly
+    // interested in the _source properties but may occasionally want other props like _id.
+    // This will be removed with #28 when a contexture-elasticsearch upgrade is complete
     return _.map(
       r => ({ ..._.omit(['_source'], r), ..._.getOr({}, '_source', r) }),
       F.cascade(['response.results', 'results'], result.context)

--- a/src/dataStrategies.js
+++ b/src/dataStrategies.js
@@ -59,7 +59,7 @@ export const results = ({
     scrollId = result.context.scrollId
     page++
     return _.map(
-      F.getOrReturn('_source'),
+      r => ({ ..._.omit(['_source'], r), ..._.getOr({}, '_source', r) }),
       F.cascade(['response.results', 'results'], result.context)
     )
   }

--- a/src/futil.js
+++ b/src/futil.js
@@ -1,0 +1,6 @@
+import _ from 'lodash/fp'
+import F from 'futil'
+
+export let flattenProp = _.curry((prop, target) =>
+  _.flow(F.expandObject(_.get(prop)), _.unset(prop))(target)
+)

--- a/test/dataStrategies.test.js
+++ b/test/dataStrategies.test.js
@@ -17,7 +17,7 @@ describe('dataStrategies', () => {
   }
 
   describe('results', () => {
-    let simpleRecords = ['record1', 'record2', 'record3']
+    let simpleRecords = [{ name: 'record1' }, { name: 'record2' }, { name: 'record3' }]
 
     let getSimpleService = wrap =>
       jest.fn(tree => {


### PR DESCRIPTION
Fixes #27 

### Description
* results dataStrategy: flattens _source onto the results items rather than picking it off so that additional props like _id can be exported