### PR TITLE
Feature/30 - allow omitting columns from CSV rows before write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 0.2.8
+﻿# 0.2.9
+* `CSVStream` exportStreategy: allow modifying search results before writing rows
+
+# 0.2.8
 * `results` dataStrategy: spread `_source` onto results items.
 
 # 0.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ﻿# 0.2.9
-* `CSVStream` exportStreategy: allow modifying search results before writing rows
+* `CSVStream` exportStreategy: allow omitting fields from CSV rows
 
 # 0.2.8
 * `results` dataStrategy: spread `_source` onto results items.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -103,7 +103,7 @@ export const CSVStream = async ({
   let records = 0
   let totalRecords = await strategy.getTotalRecords()
   let includeKeys = _.getOr([], 'include', strategy)
-  let columnHeaders = formatHeaders(formatRules)(includeKeys)
+  let columnHeaders = formatHeaders(formatRules)(_.difference(includeKeys, omitFieldsFromResult))
 
   await onWrite({
     chunk: [],

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -59,12 +59,12 @@ export let formatValues = (rules = {}, includeKeys = []) => {
   )
 }
 
-export let formatValuesWitOmits = (rules, includeKeys, omitFieldsFromResult = []) => {
+export let formatValuesWithOmits = (rules, includeKeys, omitFieldsFromResult = []) => {
   let formatter = formatValues(rules, includeKeys)
 
-  return r => {
-    let result = formatter(r)
-    return [_.omit(omitFieldsFromResult, result), result]
+  return chunk => {
+    let result = formatter(chunk)
+    return [_.map(_.omit(omitFieldsFromResult), result), result]
   }
 }
   
@@ -124,7 +124,7 @@ export const CSVStream = async ({
       }
 
       // Format the values in the current chunk with the passed in formatRules and fill any blank props
-      let [formattedData, fullFormattedData] = formatValuesWitOmits(formatRules, includeKeys, omitFieldsFromResult)(chunk)
+      let [formattedData, fullFormattedData] = formatValuesWithOmits(formatRules, includeKeys, omitFieldsFromResult)(chunk)
 
       // Convert data to CSV rows
       let rows = extractValues(formattedData, includeKeys)

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -86,6 +86,7 @@ export const CSVStream = async ({
   strategy,
   stream: targetStream,
   onWrite,
+  transformResults = _.identity,
   formatRules = {},
   logger = console.info,
 }) => {
@@ -111,6 +112,9 @@ export const CSVStream = async ({
         // Format column headers
         columnHeaders = formatHeaders(formatRules)(includeKeys)
       }
+
+      // allow the calling code to modify the results rows (e.g. to remove unwanted fields)
+      chunk = transformResults(chunk)
 
       // Format the values in the current chunk with the passed in formatRules and fill any blank props
       let formattedData = formatValues(formatRules, includeKeys)(chunk)

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -86,7 +86,7 @@ export const CSVStream = async ({
   strategy,
   stream: targetStream,
   onWrite,
-  transformResults = _.identity,
+  transformResult,
   formatRules = {},
   logger = console.info,
 }) => {
@@ -114,7 +114,9 @@ export const CSVStream = async ({
       }
 
       // allow the calling code to modify the results rows (e.g. to remove unwanted fields)
-      chunk = await transformResults(chunk)
+      if (transformResult) {
+        chunk = await Promise.all(_.map(transformResult, chunk))
+      }
 
       // Format the values in the current chunk with the passed in formatRules and fill any blank props
       let formattedData = formatValues(formatRules, includeKeys)(chunk)

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -39,7 +39,7 @@ export const stream = _.curry(async ({ strategy, stream }) => {
 
 // Format object values based on passed formatter or _.identity
 // Also fill in any keys which are present in the included keys but not in the passed in object
-export let formatValues = (rules = {}, includeKeys = [], omitFieldsFromResult) => {
+export let formatValues = (rules = {}, includeKeys = [], omitFieldsFromResult = []) => {
   let defaults = _.flow(
     _.map(x => [x, '']),
     _.fromPairs
@@ -58,8 +58,11 @@ export let formatValues = (rules = {}, includeKeys = [], omitFieldsFromResult) =
     _.flow(formattedRecordValues, _.defaults(F.unflattenObject(defaults)))
   )
 
-  return omitFieldsFromResult ? _.omit(omitFieldsFromResult, result) : result
+  return [_.omit(omitFieldsFromResult, result), result]
 }
+
+console.log('~typeof~')
+console.log(typeof formatValues)
 
 // Format the column headers with passed rules or _.startCase
 export const formatHeaders = (rules, defaultLabel = _.startCase) =>
@@ -116,7 +119,7 @@ export const CSVStream = async ({
       }
 
       // Format the values in the current chunk with the passed in formatRules and fill any blank props
-      let formattedData = formatValues(formatRules, includeKeys, omitFieldsFromResult)(chunk)
+      let [formattedData, fullFormattedData] = formatValues(formatRules, includeKeys, omitFieldsFromResult)(chunk)
 
       // Convert data to CSV rows
       let rows = extractValues(formattedData, includeKeys)
@@ -132,7 +135,7 @@ export const CSVStream = async ({
       records += chunk.length
       await targetStream.write(csv)
       await onWrite({
-        chunk: formattedData,
+        chunk: fullFormattedData,
         records,
         totalRecords,
       })

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -59,16 +59,6 @@ export let formatValues = (rules = {}, includeKeys = []) => {
   )
 }
 
-export let formatValuesWithOmits = (rules, includeKeys, omitFieldsFromResult = []) => {
-  let formatter = formatValues(rules, includeKeys)
-
-  return chunk => {
-    let result = formatter(chunk)
-    return [_.map(_.omit(omitFieldsFromResult), result), result]
-  }
-}
-  
-
 // Format the column headers with passed rules or _.startCase
 export const formatHeaders = (rules, defaultLabel = _.startCase) =>
   _.map(key => _.get([key, 'label'], rules) || defaultLabel(key))
@@ -124,7 +114,7 @@ export const CSVStream = async ({
       }
 
       // Format the values in the current chunk with the passed in formatRules and fill any blank props
-      let [formattedData, fullFormattedData] = formatValuesWithOmits(formatRules, includeKeys, omitFieldsFromResult)(chunk)
+      let formattedData = formatValues(formatRules, includeKeys)(chunk)
 
       // Convert data to CSV rows
       let rows = extractValues(formattedData, _.difference(includeKeys, omitFieldsFromResult))
@@ -140,7 +130,7 @@ export const CSVStream = async ({
       records += chunk.length
       await targetStream.write(csv)
       await onWrite({
-        chunk: fullFormattedData,
+        chunk: formattedData,
         records,
         totalRecords,
       })

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -96,7 +96,7 @@ export const CSVStream = async ({
   strategy,
   stream: targetStream,
   onWrite,
-  omitFieldsFromResult,
+  omitFieldsFromResult = [],
   formatRules = {},
   logger = console.info,
 }) => {
@@ -127,7 +127,7 @@ export const CSVStream = async ({
       let [formattedData, fullFormattedData] = formatValuesWithOmits(formatRules, includeKeys, omitFieldsFromResult)(chunk)
 
       // Convert data to CSV rows
-      let rows = extractValues(formattedData, includeKeys)
+      let rows = extractValues(formattedData, _.difference(includeKeys, omitFieldsFromResult))
 
       // Prepend column headers on first pass
       if (!records) {

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -114,7 +114,7 @@ export const CSVStream = async ({
       }
 
       // allow the calling code to modify the results rows (e.g. to remove unwanted fields)
-      chunk = transformResults(chunk)
+      chunk = await transformResults(chunk)
 
       // Format the values in the current chunk with the passed in formatRules and fill any blank props
       let formattedData = formatValues(formatRules, includeKeys)(chunk)

--- a/src/exportStrategies.js
+++ b/src/exportStrategies.js
@@ -61,9 +61,6 @@ export let formatValues = (rules = {}, includeKeys = [], omitFieldsFromResult = 
   return [_.omit(omitFieldsFromResult, result), result]
 }
 
-console.log('~typeof~')
-console.log(typeof formatValues)
-
 // Format the column headers with passed rules or _.startCase
 export const formatHeaders = (rules, defaultLabel = _.startCase) =>
   _.map(key => _.get([key, 'label'], rules) || defaultLabel(key))

--- a/test/exportStrategies.test.js
+++ b/test/exportStrategies.test.js
@@ -214,7 +214,6 @@ describe('exportStrategies', () => {
       extractValues,
       formatHeaders,
       formatValues,
-      formatValuesWithOmits,
       rowsToCSV,
       extractHeadersFromFirstRow,
     } = exportStrategies

--- a/test/exportStrategies.test.js
+++ b/test/exportStrategies.test.js
@@ -383,62 +383,6 @@ describe('exportStrategies', () => {
         },
       ])
     })
-    it('formatValuesWithOmits should omit omitted fields', () => {
-      let columnKeys = [
-        'AgencyName',
-        'FullName',
-        'Title',
-        'AgencyType',
-        'AddressState',
-      ]
-      let data = [
-        {
-          AgencyName: 'ABC',
-          AgencyType: 'Private Schools',
-          AddressState: 'IL',
-        },
-        {
-          AgencyName: 'DEF',
-          FullName: 'D P',
-          Title: 'Auditor',
-          AgencyType: 'State',
-          AddressState: 'CA',
-        },
-        { AddressState: 'FL' },
-      ]
-      let rules = {
-        AgencyType: {
-          display: _.toUpper,
-        },
-        AddressState: {
-          display: _.toLower,
-        },
-      }
-      let results = formatValuesWithOmits(rules, columnKeys, ['Title'])(data)
-      // first element of results array has the record with omits applied
-      let result = _.first(results)
-
-      expect(result).toEqual([
-        {
-          AgencyName: 'ABC',
-          AgencyType: 'PRIVATE SCHOOLS',
-          AddressState: 'il',
-          FullName: '',
-        },
-        {
-          AgencyName: 'DEF',
-          AgencyType: 'STATE',
-          AddressState: 'ca',
-          FullName: 'D P',
-        },
-        {
-          AgencyName: '',
-          AgencyType: '',
-          AddressState: 'fl',
-          FullName: '',
-        },
-      ])
-    })
     it('formatHeaders with no rules', () => {
       expect(formatHeaders({})(columnKeys)).toEqual(['Name', 'Age'])
     })

--- a/test/exportStrategies.test.js
+++ b/test/exportStrategies.test.js
@@ -214,6 +214,7 @@ describe('exportStrategies', () => {
       extractValues,
       formatHeaders,
       formatValues,
+      formatValuesWithOmits,
       rowsToCSV,
       extractHeadersFromFirstRow,
     } = exportStrategies
@@ -378,6 +379,62 @@ describe('exportStrategies', () => {
           AgencyType: '',
           AddressState: 'fl',
           Title: '',
+          FullName: '',
+        },
+      ])
+    })
+    it('formatValuesWithOmits should omit omitted fields', () => {
+      let columnKeys = [
+        'AgencyName',
+        'FullName',
+        'Title',
+        'AgencyType',
+        'AddressState',
+      ]
+      let data = [
+        {
+          AgencyName: 'ABC',
+          AgencyType: 'Private Schools',
+          AddressState: 'IL',
+        },
+        {
+          AgencyName: 'DEF',
+          FullName: 'D P',
+          Title: 'Auditor',
+          AgencyType: 'State',
+          AddressState: 'CA',
+        },
+        { AddressState: 'FL' },
+      ]
+      let rules = {
+        AgencyType: {
+          display: _.toUpper,
+        },
+        AddressState: {
+          display: _.toLower,
+        },
+      }
+      let results = formatValuesWithOmits(rules, columnKeys, ['Title'])(data)
+      // first element of results array has the record with omits applied
+      let result = _.first(results)
+
+      expect(result).toEqual([
+        {
+          AgencyName: 'ABC',
+          AgencyType: 'PRIVATE SCHOOLS',
+          AddressState: 'il',
+          FullName: '',
+        },
+        {
+          AgencyName: 'DEF',
+          AgencyType: 'STATE',
+          AddressState: 'ca',
+          FullName: 'D P',
+        },
+        {
+          AgencyName: '',
+          AgencyType: '',
+          AddressState: 'fl',
           FullName: '',
         },
       ])


### PR DESCRIPTION
Fixes #30 

### Description
* allows omitting fields from search results before they're turned into CSV rows
* calls `onWrite` with the un-redacted row so you can handle your export with the extra columns
* use case: you need to know the values in a column in order to track your exports somehow, but you don't actually want that column in the CSV