### PR TITLE
bumped version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "0.2.10",
+  "version": "1.0.0",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {


### PR DESCRIPTION
☝️ 

We didn't bump the version in https://github.com/smartprocure/contexture-export/pull/35