### PR TITLE
Adjust terms_stats, no throw error when service returns unexpected value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿# 1.0.2
+﻿# 1.0.3
+* Adjust how `terms_stats` handles unexpected return from the service, no longer
+throws an error while iterating and returns `undefined`
+
+# 1.0.2
 * Fixed bug preventing `highlight: false` from being passed to the service.
 
 # 1.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-export",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Contexture Exports",
   "main": "lib/contexture-export.js",
   "scripts": {

--- a/src/nodes/termStats.test.js
+++ b/src/nodes/termStats.test.js
@@ -27,8 +27,10 @@ describe('terms_stats', () => {
       return tree
     })
 
-  let prepareSimpleStrategy = async (strategyParams = {}) => {
-    let service = getSimpleService()
+  let prepareSimpleStrategy = async ({
+    strategyParams = {},
+    service = getSimpleService(),
+  } = {}) => {
     let tree = _.cloneDeep(defaultTree)
     let strategy = await terms_stats({
       service,
@@ -39,7 +41,9 @@ describe('terms_stats', () => {
   }
 
   it('retrieves the total records (same as the given size)', async () => {
-    let strategy = await prepareSimpleStrategy({ size: 1337 })
+    let strategy = await prepareSimpleStrategy({
+      strategyParams: { size: 1337 },
+    })
     expect(strategy.getTotalRecords()).toBe(1337)
   })
   it('retrieves records with next', async () => {
@@ -47,5 +51,11 @@ describe('terms_stats', () => {
     let arr = []
     for await (const i of strategy) arr.push(i)
     expect(arr).toEqual([simpleRecords])
+  })
+  it('doesnt throw error when service returns unexpected result', async () => {
+    let strategy = await prepareSimpleStrategy({ service: jest.fn(_.identity) })
+    let arr = []
+    for await (const i of strategy) arr.push(i)
+    expect(arr).toEqual([undefined])
   })
 })

--- a/src/nodes/terms_stats.js
+++ b/src/nodes/terms_stats.js
@@ -27,7 +27,7 @@ export default async ({ service, tree, ...node }) => {
         size: size || totalRecords,
         ...node,
       }))
-      yield node.context.terms
+      yield _.get('context.terms', node)
     },
   }
   return terms_stats


### PR DESCRIPTION
This makes debugging more strait forward as the `node` will be more easily accessible
(no need to catch and look at the object you were iterating on) and allows the client to decide how
to handle when the service doesn't return the data by handling an `undefined` value.